### PR TITLE
add Swedish to language codes

### DIFF
--- a/library/ftx/ftx_sct_services.pas
+++ b/library/ftx/ftx_sct_services.pas
@@ -5178,6 +5178,8 @@ begin
     result := 3
   else if (s = 'es') then
     result := 4
+  else if (s = 'sv') then
+    result := 5
   else
     raise ETerminologyError.create('Unknown SCT Lang "'+s+'"');
 end;
@@ -5189,6 +5191,7 @@ begin
     2 : result := 'fr';
     3 : result := 'nl';
     4 : result := 'es';
+    5 : result := 'sv';
   else
     result := '??';
   end;


### PR DESCRIPTION
Added 'sv' (Swedish) as a fifth language recognized by readLang and codeForLang.
For 25 years until today I have not produced a single line of Pascal.