### PR TITLE
Add ISO 3166-1 user-assigned code elements

### DIFF
--- a/server/tx/tx_countrycode.pas
+++ b/server/tx/tx_countrycode.pas
@@ -468,7 +468,7 @@ begin
   doLoad('XH', 'User-assigned');
   doLoad('XI', 'User-assigned');
   doLoad('XJ', 'User-assigned');
-  doLoad('XK', 'User-assigned');  // Note: XK is also used for Kosovo by the European Commission
+  doLoad('XK', 'Kosovo');
   doLoad('XL', 'User-assigned');
   doLoad('XM', 'User-assigned');
   doLoad('XN', 'User-assigned');
@@ -481,10 +481,10 @@ begin
   doLoad('XU', 'User-assigned');
   doLoad('XV', 'User-assigned');
   doLoad('XW', 'User-assigned');
-  doLoad('XX', 'User-assigned');  // Commonly used for "Unknown" or "Unspecified"
-  doLoad('XY', 'User-assigned');  // Commonly used for "Anonymous" (privacy)
-  doLoad('XZ', 'User-assigned');
-  doLoad('ZZ', 'User-assigned');  // Commonly used for "Unknown" or "International"
+  doLoad('XX', 'Unknown');
+  doLoad('XY', 'User-assigned');
+  doLoad('XZ', 'International Waters');
+  doLoad('ZZ', 'Unknown or Invalid Territory');
 
   doLoad('ABW', 'Aruba');
   doLoad('AFG', 'Afghanistan');

--- a/server/tx/tx_countrycode.pas
+++ b/server/tx/tx_countrycode.pas
@@ -440,6 +440,52 @@ begin
   doLoad('ZM', 'Zambia');
   doLoad('ZW', 'Zimbabwe');
 
+  // ISO 3166-1 User-assigned code elements
+  // These codes are reserved for user assignment and will never be used for country names
+  // See: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements
+  doLoad('AA', 'User-assigned');
+  doLoad('QM', 'User-assigned');
+  doLoad('QN', 'User-assigned');
+  doLoad('QO', 'User-assigned');
+  doLoad('QP', 'User-assigned');
+  doLoad('QQ', 'User-assigned');
+  doLoad('QR', 'User-assigned');
+  doLoad('QS', 'User-assigned');
+  doLoad('QT', 'User-assigned');
+  doLoad('QU', 'User-assigned');
+  doLoad('QV', 'User-assigned');
+  doLoad('QW', 'User-assigned');
+  doLoad('QX', 'User-assigned');
+  doLoad('QY', 'User-assigned');
+  doLoad('QZ', 'User-assigned');
+  doLoad('XA', 'User-assigned');
+  doLoad('XB', 'User-assigned');
+  doLoad('XC', 'User-assigned');
+  doLoad('XD', 'User-assigned');
+  doLoad('XE', 'User-assigned');
+  doLoad('XF', 'User-assigned');
+  doLoad('XG', 'User-assigned');
+  doLoad('XH', 'User-assigned');
+  doLoad('XI', 'User-assigned');
+  doLoad('XJ', 'User-assigned');
+  doLoad('XK', 'User-assigned');  // Note: XK is also used for Kosovo by the European Commission
+  doLoad('XL', 'User-assigned');
+  doLoad('XM', 'User-assigned');
+  doLoad('XN', 'User-assigned');
+  doLoad('XO', 'User-assigned');
+  doLoad('XP', 'User-assigned');
+  doLoad('XQ', 'User-assigned');
+  doLoad('XR', 'User-assigned');
+  doLoad('XS', 'User-assigned');
+  doLoad('XT', 'User-assigned');
+  doLoad('XU', 'User-assigned');
+  doLoad('XV', 'User-assigned');
+  doLoad('XW', 'User-assigned');
+  doLoad('XX', 'User-assigned');  // Commonly used for "Unknown" or "Unspecified"
+  doLoad('XY', 'User-assigned');  // Commonly used for "Anonymous" (privacy)
+  doLoad('XZ', 'User-assigned');
+  doLoad('ZZ', 'User-assigned');  // Commonly used for "Unknown" or "International"
+
   doLoad('ABW', 'Aruba');
   doLoad('AFG', 'Afghanistan');
   doLoad('AGO', 'Angola');


### PR DESCRIPTION
ISO 3166-1 reserves certain alpha-2 codes for user assignment:
- AA
- QM to QZ
- XA to XZ
- ZZ

These codes are part of the ISO 3166-1 standard and are reserved for users who need to add further code elements for their own purposes. They will never be assigned to actual country names by ISO.

Common uses include:
- XX: Unknown or Unspecified Country
- XY: Anonymous Country (for privacy)
- XK: Kosovo (used by European Commission)
- ZZ: Unknown or International

Reference: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#User-assigned_code_elements